### PR TITLE
chore: upgrade to pnpm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9.15.9
+          version: 11.5.2
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9.15.9
+          version: 11.5.2
           run_install: false
 
       - name: Setup Node.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-shamefully-hoist=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
   - `src/preload/`: preload scripts (secure API bridge)
   - `src/renderer/`: frontend UI (React + shadcn/ui + Tailwind CSS)
 
-Use pnpm as the package manager
+Use pnpm as the package manager (v11; CI pins `11.5.2`). pnpm settings belong in `pnpm-workspace.yaml` (`allowBuilds`, `shamefullyHoist`), not `package.json#pnpm` or `.npmrc`.
 
 #### Code Quality Conventions
 

--- a/package.json
+++ b/package.json
@@ -62,11 +62,5 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.10"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "electron",
-      "esbuild"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+allowBuilds:
+  electron: true
+  esbuild: true
+  electron-winstaller: false
+  msw: false
+
+shamefullyHoist: true


### PR DESCRIPTION
- Pin pnpm 11.5.2 in CI and E2E workflows
- Migrate onlyBuiltDependencies to pnpm-workspace.yaml allowBuilds
- Move shamefullyHoist from .npmrc into pnpm-workspace.yaml (pnpm 11 config split)

Assisted-by: Cursor (cloud agent)