### PR TITLE
ci: disable pnpm minimumReleaseAge in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   build:
     name: Package (${{ matrix.os }})
+    env:
+      pnpm_config_minimum_release_age: '0'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    env:
+      pnpm_config_minimum_release_age: '0'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
## Summary

pnpm 11 defaults `minimumReleaseAge` to 1440 minutes (1 day), which can block CI from installing recently published packages even when the lockfile already pins them.

This PR sets `pnpm_config_minimum_release_age=0` in both CI workflows so installs in CI are not blocked by the release-age guardrail.

## Changes

- `.github/workflows/ci.yml`: add job-level `pnpm_config_minimum_release_age: '0'`
- `.github/workflows/e2e.yml`: add job-level `pnpm_config_minimum_release_age: '0'`

## Notes

Local installs keep pnpm 11's default protection unless overridden elsewhere. Only CI/E2E jobs opt out via environment variable.